### PR TITLE
fix: attested claim needs to be deep-copied (call by reference issue)

### DIFF
--- a/src/containers/workflows/ChooseClaimForCtype/ChooseClaimForCtype.tsx
+++ b/src/containers/workflows/ChooseClaimForCtype/ChooseClaimForCtype.tsx
@@ -293,12 +293,14 @@ class ChooseClaimForCtype extends React.Component<Props, State> {
       headline: 'Resolving receiver (1/2)',
     })
 
+    const excludedProperties = this.getExcludedProperties()
     const request: SubmitClaimForCtype = {
       content: selectedAttestations.map(
         (selectedAttestedClaim: sdk.IAttestedClaim) => {
-          return sdk.AttestedClaim.fromObject(
-            selectedAttestedClaim
-          ).createPresentation(this.getExcludedProperties())
+          const attestedClaim = sdk.AttestedClaim.fromObject(
+            this.deepCopy(selectedAttestedClaim)
+          ).createPresentation(excludedProperties)
+          return attestedClaim
         }
       ),
       type: MessageBodyType.SUBMIT_CLAIM_FOR_CTYPE,
@@ -336,6 +338,11 @@ class ChooseClaimForCtype extends React.Component<Props, State> {
         })
       }
     })
+  }
+
+  // TODO better externalize for reusability
+  private deepCopy(attestedClaim: sdk.IAttestedClaim): sdk.IAttestedClaim {
+    return JSON.parse(JSON.stringify(attestedClaim)) as sdk.IAttestedClaim
   }
 }
 


### PR DESCRIPTION
Beim Erzeugen der Presentation werden die Properties per call-by-reference im Claim gelöscht. Hat man den Claim im Store, so werden auch dort die Properties entfernt.

Der Fix macht ein Deep-Copy des AttestedClaim vor dem Erzeugen der Presentation.