### PR TITLE
feat: make new schema formats usable with editor

### DIFF
--- a/src/components/SchemaEditor/SchemaEditor.tsx
+++ b/src/components/SchemaEditor/SchemaEditor.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { JSONEditor } from 'react-schema-based-json-editor'
 import * as common from 'schema-based-json-editor'
-import { Claim } from '@kiltprotocol/prototype-sdk'
 
 import './SchemaEditor.scss'
 
@@ -11,50 +10,17 @@ type Props = {
   updateValue: (value: common.ValueType, _isValid: boolean) => void
 }
 
-class SchemaEditor extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props)
-
-    this.prepareTimeValuesAndUpdate = this.prepareTimeValuesAndUpdate.bind(this)
-  }
-
-  public render() {
-    const { schema, initialValue } = this.props
-    return (
-      <div className="schema-based-json-editor">
-        <JSONEditor
-          schema={schema}
-          initialValue={initialValue}
-          updateValue={this.prepareTimeValuesAndUpdate}
-          icon="fontawesome5"
-        />
-      </div>
-    )
-  }
-
-  private prepareTimeValuesAndUpdate(
-    contents: Claim['contents'],
-    isValid: boolean
-  ) {
-    const { updateValue, schema } = this.props
-
-    for (const prop in contents) {
-      if (
-        contents.hasOwnProperty(prop) &&
-        // is time format in schema
-        // @ts-ignore
-        schema.properties[prop].format === 'time' &&
-        // not empty
-        contents[prop] &&
-        // Only, if format is 00:00 (where 0 can be any digit), add another :00
-        contents[prop].match(/^\d{2}:\d{2}$/)
-      ) {
-        contents[prop] = `${contents[prop]}:00`
-      }
-    }
-
-    updateValue(contents, isValid)
-  }
+const SchemaEditor = ({ schema, initialValue, updateValue }: Props) => {
+  return (
+    <div className="schema-based-json-editor">
+      <JSONEditor
+        schema={schema}
+        initialValue={initialValue}
+        updateValue={updateValue}
+        icon="fontawesome5"
+      />
+    </div>
+  )
 }
 
 export default SchemaEditor

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,10 +510,12 @@
 "@types/dragula@*":
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/@types/dragula/-/dragula-2.1.34.tgz#48ecf8627860e6179efc222dd5390b37dbd42d9d"
+  integrity sha512-tZbauiqJgEpKKtBQI8pQ24FrkDNGhiXCFsygqQPeAJTPJJC1RI0BOmHv7VHI9qDehhXXffq9aJEUhqEQyY/PVA==
 
 "@types/highlight.js@*":
   version "9.12.3"
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
+  integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
 "@types/history@*":
   version "4.7.2"
@@ -535,14 +537,16 @@
 "@types/json5@*":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.30.tgz#44cb52f32a809734ca562e685c6473b5754a7818"
+  integrity sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
 
 "@types/linkify-it@*":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-2.0.4.tgz#80a7f9aec4c9283e8333debda5a88511d4a529a7"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-2.1.0.tgz#ea3dd64c4805597311790b61e872cbd1ed2cd806"
+  integrity sha512-Q7DYAOi9O/+cLLhdaSvKdaumWyHbm7HAk/bFwwyTuU0arR5yyCeW5GOoqt4tJTpDRxhpx9Q8kQL6vMpuw9hDSw==
 
 "@types/lodash@^4.14.118":
   version "4.14.118"
@@ -551,6 +555,7 @@
 "@types/markdown-it@*":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-0.0.7.tgz#75070485a3d8ad11e7deb8287f4430be15bf4d39"
+  integrity sha512-WyL6pa76ollQFQNEaLVa41ZUUvDvPY+qAUmlsphnrpL6I9p1m868b26FyeoOmo7X3/Ta/S9WKXcEYXUSHnxoVQ==
   dependencies:
     "@types/linkify-it" "*"
 
@@ -3829,12 +3834,14 @@ file-loader@1.1.5:
 file-uploader-component@7, file-uploader-component@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/file-uploader-component/-/file-uploader-component-7.4.1.tgz#4ea39dbfb38475a89a2f7ea1fc2888f5aabe5cb6"
+  integrity sha512-iflocSWrW64Ng6PRfV6d7BDTZvS+tW7NGfM/ZhAtLt37drYI6g+ciz7kyIIyPgYREyAQWVSAb6mQ1p3FiUgVGQ==
   dependencies:
     tslib "1"
 
 file-uploader-react-component@7:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/file-uploader-react-component/-/file-uploader-react-component-7.4.1.tgz#fe1b469321af0ae3ae2a685694982a0bfd2c6c17"
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/file-uploader-react-component/-/file-uploader-react-component-7.5.0.tgz#788af0a0af8e69d327db87c20190a5c392d695d1"
+  integrity sha512-C+gj2uY+SU6KFWDC4ze6TCI3+cB3ctTDfdS7MFX70OXPxKnqma/qKw4tnVsExU35z8EHXpoKOpz373h9iGSJ7g==
   dependencies:
     file-uploader-component "^7.4.1"
     react "16"
@@ -5662,6 +5669,7 @@ js-sha3@^0.8.0:
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -5778,6 +5786,7 @@ json3@^3.3.2:
 json5@2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -6079,10 +6088,12 @@ lodash.isfunction@^3.0.8:
 lodash.isinteger@4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
 
 lodash.isobject@3:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -6181,10 +6192,12 @@ lodash.templatesettings@^4.0.0:
 lodash.tointeger@4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.tointeger/-/lodash.tointeger-4.0.4.tgz#65e655acaa724e26d3fef57effc46970e1cd17e6"
+  integrity sha1-ZeZVrKpyTibT/vV+/8RpcOHNF+Y=
 
 lodash.tonumber@4:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz#0b96b31b35672793eb7f5a63ee791f1b9e9025d9"
+  integrity sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk=
 
 lodash.topairs@4.3.0:
   version "4.3.0"
@@ -6295,6 +6308,7 @@ map-visit@^1.0.0:
 markdown-tip-react@6:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/markdown-tip-react/-/markdown-tip-react-6.4.1.tgz#4939cc63ac890efc79cbe54590640753dbbbaedb"
+  integrity sha512-gQ3lBRpuzykdGUgMSiZ5lj+4WWiKdttWvOhoXknHCk6sfjENB81XVztOzdCgLHiovuC8XQtXoRNkdU9tb/f90Q==
   dependencies:
     markdown-tip "^6.4.1"
     react "16"
@@ -6303,6 +6317,7 @@ markdown-tip-react@6:
 markdown-tip@6, markdown-tip@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/markdown-tip/-/markdown-tip-6.4.1.tgz#b30c4aa264759145710d8c9fb3a0b117ebe63b24"
+  integrity sha512-V1S5vdpt7mDWJNcc4ukIg/MqVVZO11dSS/KLdT9TqRAw9D9Z36El1tOCMjf7s9jU9iJVVlnrvDQ6pn38pzLZFg==
   dependencies:
     tslib "1"
 
@@ -6580,9 +6595,10 @@ moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
 
-monaco-editor@0.15:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.15.6.tgz#d63b3b06f86f803464f003b252627c3eb4a09483"
+monaco-editor@0.16:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.16.2.tgz#950084ed82eeaef1c8c9d3c1bcab849fe11b2415"
+  integrity sha512-NtGrFzf54jADe7qsWh3lazhS7Kj0XHkJUGBq9fA/Jbwc+sgVcyfsYF6z2AQ7hPqDC+JmdOt/OwFjBnRwqXtx6w==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -7484,12 +7500,21 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -7688,7 +7713,17 @@ react-dev-utils@^5.0.2:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@16, react-dom@^16.6.3:
+react-dom@16:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
+react-dom@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
   dependencies:
@@ -7710,6 +7745,11 @@ react-input-autosize@^2.2.1:
 react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-json-view@^1.19.1:
   version "1.19.1"
@@ -7760,8 +7800,9 @@ react-router@^4.3.1:
     warning "^4.0.1"
 
 react-schema-based-json-editor@^7.20.2:
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/react-schema-based-json-editor/-/react-schema-based-json-editor-7.20.2.tgz#4a9d44af4109cd9842e857cb4c195659b8c5ad1e"
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/react-schema-based-json-editor/-/react-schema-based-json-editor-7.22.0.tgz#71277981aa8027bc4c28de648e564bed61b73bec"
+  integrity sha512-Zv9sJ7XUSQ6AnJ6QZE/4PPAFA1n5P2OXxwk6JTUlbrrienc9YVZDw61VgGN7KebfD63XdqWH+x2dV5+m5XVCTw==
   dependencies:
     "@types/dragula" "*"
     "@types/highlight.js" "*"
@@ -7772,7 +7813,7 @@ react-schema-based-json-editor@^7.20.2:
     markdown-tip-react "6"
     react "16"
     react-dom "16"
-    schema-based-json-editor "^7.20.2"
+    schema-based-json-editor "^7.22.0"
     select2-react-component "5"
 
 react-select@^2.2.0:
@@ -7811,7 +7852,17 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16, react@^16.6.3:
+react@16:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
+react@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
   dependencies:
@@ -8329,15 +8380,25 @@ sax@^1.2.1, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 scheduler@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.3.tgz#b5769b90cf8b1464f3f3cfcafe8e3cd7555a2d6b"
+  integrity sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-based-json-editor@^7.20.2:
-  version "7.20.2"
-  resolved "https://registry.yarnpkg.com/schema-based-json-editor/-/schema-based-json-editor-7.20.2.tgz#9463cea0e75e3c16adb7d51db4026ddca81b363d"
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+schema-based-json-editor@^7.22.0:
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/schema-based-json-editor/-/schema-based-json-editor-7.22.0.tgz#6e278ec7278ad4ee774daec28f67fbcaae26d782"
+  integrity sha512-UbvarRg3F3/IFFNHs8Qd/yRnDUjSPf7dA+2E1+iQBsfcyBGQB6yt106VqhhQVWovYLILUed84CT92V48lXJHCQ==
   dependencies:
     "@types/dragula" "*"
     "@types/highlight.js" "*"
@@ -8347,7 +8408,7 @@ schema-based-json-editor@^7.20.2:
     lodash.tointeger "4"
     lodash.tonumber "4"
     markdown-tip "6"
-    monaco-editor "0.15"
+    monaco-editor "0.16"
     select2-component "5"
     tslib "1"
 
@@ -8400,6 +8461,7 @@ select-hose@^2.0.0:
 select2-component@5, select2-component@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/select2-component/-/select2-component-5.5.1.tgz#7e09d947dcbc707402dd8731cdb450f7d21e953f"
+  integrity sha512-5q5JoBQh9kJOatW1ZEsOmkkGhB/6Dfr/FAtYOtBwaRECEIzM5PsBLCi2+Crfy9jN08/ySbOWEgce3ff9maw9oQ==
   dependencies:
     "@types/node" "*"
     tslib "1"
@@ -8407,6 +8469,7 @@ select2-component@5, select2-component@^5.5.1:
 select2-react-component@5:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/select2-react-component/-/select2-react-component-5.5.1.tgz#47f9528cd8f6dade6a327f52db286b02a4741f97"
+  integrity sha512-czhfEUEcAiVOlGDUthd3wW9rSV9p/4izF6GiGG54AuvvQ0zyxgUaGtogymOcet5fTGAjf6vfsDQmrB4A32RtVA==
   dependencies:
     "@types/node" "*"
     react "16"


### PR DESCRIPTION
This PR is necessary, to make the time format work in the json editor.

The editor returns the time not according to the json-schema. I opened up an issue for that: https://github.com/plantain-00/schema-based-json-editor/issues/23

This workaround adds `00+00:00`, if it is not there.

https://github.com/KILTprotocol/prototype-sdk/pull/95 is needs for this to test.