### PR TITLE
Lockfileversioning/tsc3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.1.6",
+    "typescript": "3.1.6",
     "uglifyjs-webpack-plugin": "1.2.5",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.11.3",
@@ -154,11 +154,7 @@
       "node",
       "mjs"
     ],
-    "globals": {
-      "ts-jest": {
-        "tsConfigFile": "/Users/mwoywode/Documents/workspace/KILT/prototype-client/tsconfig.test.json"
-      }
-    }
+    "globals": {}
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "3.1.6",
+    "typescript": "^3.1.6",
     "uglifyjs-webpack-plugin": "1.2.5",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.11.3",
@@ -154,7 +154,11 @@
       "node",
       "mjs"
     ],
-    "globals": {}
+    "globals": {
+      "ts-jest": {
+        "tsConfigFile": "/Users/mwoywode/Documents/workspace/KILT/prototype-client/tsconfig.test.json"
+      }
+    }
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sw-precache-webpack-plugin": "0.11.4",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.1.6",
+    "typescript": "3.1.6",
     "uglifyjs-webpack-plugin": "1.2.5",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,9 +8938,10 @@ typescript-logging@^0.6.3:
   dependencies:
     stacktrace-js "1.3.1"
 
-typescript@^3.1.6:
+typescript@3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,10 +8938,9 @@ typescript-logging@^0.6.3:
   dependencies:
     stacktrace-js "1.3.1"
 
-typescript@3.1.6:
+typescript@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,7 +8938,7 @@ typescript-logging@^0.6.3:
   dependencies:
     stacktrace-js "1.3.1"
 
-typescript@^3.1.6:
+typescript@3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
 


### PR DESCRIPTION
## fixes #221 

Changed the Version we are using in the lockfiles to be exact 3.1.6, since we have no upwards compability.


## How to test:
have tsc version above 3.2.0 installed
run yarn install&yarn start or npm install npm start
no errors should occur when starting the dev server