### PR TITLE
feat: append address when requesting tokens

### DIFF
--- a/src/components/IdentityView/IdentityView.tsx
+++ b/src/components/IdentityView/IdentityView.tsx
@@ -167,10 +167,7 @@ class IdentityView extends React.Component<Props, State> {
           {!(balance > 0) && (
             <button
               className="requestTokens"
-              onClick={this.openKiltFaucet.bind(
-                this,
-                myIdentity.identity.address
-              )}
+              onClick={this.openKiltFaucet(myIdentity.identity.address)}
               title="Request Tokens"
             >
               Request Tokens
@@ -217,7 +214,9 @@ class IdentityView extends React.Component<Props, State> {
   }
 
   private openKiltFaucet(address: Identity['address']) {
-    window.open(FAUCET_URL + '?' + address, '_blank')
+    return () => {
+      window.open(FAUCET_URL + '?' + address, '_blank')
+    }
   }
 
   private toggleContacts() {

--- a/src/components/IdentityView/IdentityView.tsx
+++ b/src/components/IdentityView/IdentityView.tsx
@@ -86,7 +86,7 @@ class IdentityView extends React.Component<Props, State> {
             <div>{myIdentity.phrase}</div>
           </div>
           <div>
-            <label>Address</label>
+            <label>KILT Address</label>
             <div>{myIdentity.identity.address}</div>
           </div>
           <div>

--- a/src/components/IdentityView/IdentityView.tsx
+++ b/src/components/IdentityView/IdentityView.tsx
@@ -15,6 +15,7 @@ import ContactPresentation from '../ContactPresentation/ContactPresentation'
 
 import './IdentityView.scss'
 import MessageRepository from '../../services/MessageRepository'
+import { Identity } from '@kiltprotocol/sdk-js'
 
 type Props = {
   // input
@@ -166,7 +167,10 @@ class IdentityView extends React.Component<Props, State> {
           {!(balance > 0) && (
             <button
               className="requestTokens"
-              onClick={this.openKiltFaucet}
+              onClick={this.openKiltFaucet.bind(
+                this,
+                myIdentity.identity.address
+              )}
               title="Request Tokens"
             >
               Request Tokens
@@ -212,8 +216,8 @@ class IdentityView extends React.Component<Props, State> {
     )
   }
 
-  private openKiltFaucet() {
-    window.open(FAUCET_URL, '_blank')
+  private openKiltFaucet(address: Identity['address']) {
+    window.open(FAUCET_URL + '?' + address, '_blank')
   }
 
   private toggleContacts() {


### PR DESCRIPTION
## fixes #229 
Appends the address for window.open
Also say KILT address instead of address in the wallet and dashboard

## How to test:
- create identity
- request tokens on ./Wallet
- should open faucet with ?(selected identity's address here) as url parameter


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
