### PR TITLE
fix: incomplete CType registration

### DIFF
--- a/src/containers/CtypeCreate/CtypeCreate.tsx
+++ b/src/containers/CtypeCreate/CtypeCreate.tsx
@@ -63,7 +63,7 @@ class CTypeCreate extends React.Component<Props, State> {
       let cType: sdk.CType
 
       try {
-        cType = fromInputModel(this.state.cType)
+        cType = fromInputModel(this.state.cType, selectedIdentity.identity.address)
       } catch (error) {
         errorService.log({
           error,

--- a/src/utils/CtypeUtils/CtypeUtils.ts
+++ b/src/utils/CtypeUtils/CtypeUtils.ts
@@ -11,10 +11,11 @@ import { ICTypeInput, IClaimInput } from '../../types/Ctype'
  * @returns The CTYPE for the input model.
  */
 
-export const fromInputModel = (ctypeInput: ICTypeInput): sdk.CType => {
+export const fromInputModel = (ctypeInput: ICTypeInput, creator?: sdk.Identity["address"]): sdk.CType => {
   if (!sdk.CTypeUtils.verifySchema(ctypeInput, sdk.CTypeInputModel)) {
     throw new Error('CType input does not correspond to input model schema')
   }
+  const cTypeOwner = !creator ? null : creator
   const ctype = {
     schema: {
       $id: ctypeInput.$id,
@@ -31,6 +32,7 @@ export const fromInputModel = (ctypeInput: ICTypeInput): sdk.CType => {
       },
       properties: {},
     },
+    owner: cTypeOwner,
   }
 
   const properties = {}


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/174

Added optional 'creator' parameter to fromInputModel , to be used as owner property of the CType if not undefined, otherwise null.

There might be changes to the spec files required, to accomodate this change.

## How to test:
setup local demo client and services, create a ctype:

Should be registered on /ctype on services with metaData.author equal to cType.owner and not be rejected by mongodb.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
