### PR TITLE
feat: prepended protocol to URLs

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -1,4 +1,4 @@
-REACT_APP_SERVICE_HOST=//services.devnet.kilt.io
+REACT_APP_SERVICE_HOST=https://services.devnet.kilt.io
 REACT_APP_SERVICE_PORT=443
 
 REACT_APP_NODE_HOST=full-nodes-lb.devnet.kilt.io
@@ -6,4 +6,4 @@ REACT_APP_NODE_WS_PORT=443
 
 REACT_APP_FAUCET_URL=https://faucet-devnet.kilt.io
 
-PUBLIC_URL=//demo.devnet.kilt.io
+PUBLIC_URL=https://demo.devnet.kilt.io

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-REACT_APP_SERVICE_HOST=//services.kilt.io
+REACT_APP_SERVICE_HOST=https://services.kilt.io
 REACT_APP_SERVICE_PORT=443
 
 REACT_APP_NODE_HOST=full-nodes.kilt.io
@@ -6,4 +6,4 @@ REACT_APP_NODE_WS_PORT=443
 
 REACT_APP_FAUCET_URL=https://faucet.kilt.io
 
-PUBLIC_URL=//demo.kilt.io
+PUBLIC_URL=https://demo.kilt.io


### PR DESCRIPTION
## Fixes KILTProtocol/ticket#317

Prepended HTTPS to BOTH `REACT_APP_SERVICE_HOST` and `PUBLIC_URL`.
Initially, the issues were caused by `REACT_APP_SERVICE_HOST` but I thought I might as well fix `PUBLIC_URL` too.

## How to test:
Make sure that the build scripts run properly.

## Checklist:

- [ ] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
