### PR TITLE
refactor: SubmittableResult instead of TxStatus

### DIFF
--- a/src/containers/ClaimView/ClaimView.tsx
+++ b/src/containers/ClaimView/ClaimView.tsx
@@ -150,7 +150,7 @@ class ClaimView extends React.Component<Props, State> {
     }
   }
 
-  private resolveClaim(claimId: Claims.Entry['id']): sdk.Claim | undefined {
+  private resolveClaim(claimId: Claims.Entry['id']): sdk.IClaim | undefined {
     const { claimEntries } = this.props
 
     const claimToAttest = claimEntries.find(

--- a/src/services/DidService.ts
+++ b/src/services/DidService.ts
@@ -31,7 +31,7 @@ class DidService {
     } as IContact)
 
     const status = await did.store(myIdentity.identity)
-    if (status.type !== 'Finalized') {
+    if (status.isError) {
       throw new Error(
         `Error creating DID for identity ${myIdentity.metaData.name}`
       )
@@ -47,7 +47,7 @@ class DidService {
 
   public static async deleteDid(myIdentity: IMyIdentity): Promise<void> {
     const status = await sdk.Did.remove(myIdentity.identity)
-    if (status.type !== 'Finalized') {
+    if (status.isError) {
       throw new Error(
         `Error deleting DID for identity ${myIdentity.metaData.name}`
       )


### PR DESCRIPTION
## fixes KILTprotocol/ticket#392, relates to KILTprotocol/sdk-js#250
Necessary changes on the demo client when replacing `TxStatus` with `SubmittableResult` in the SDK (see ticket).

## How to test:
- checkout sdk on branch `rf-drop-TxStatus` & run `yalc publish`
- on demo client, link sdk with `yalc add '@kiltprotocol/sdk-js'`
- `yarn install`, then run & test via bootstrap tools & manual steps

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
