### PR TITLE
feat: use publicidentity as alternative to contact

### DIFF
--- a/src/components/MessageDetailView/MessageDetailView.tsx
+++ b/src/components/MessageDetailView/MessageDetailView.tsx
@@ -97,8 +97,9 @@ class MessageDetailView extends React.Component<Props, State> {
             <ClaimDetailView
               claim={(message.body as sdk.IRequestTerms).content}
             />
-            {showTask ? (
+            {showTask && message.sender ? (
               <SubmitLegitimations
+                receiver={message.sender.publicIdentity}
                 receiverAddresses={[message.senderAddress]}
                 claim={(message.body as sdk.IRequestTerms).content}
                 onCancel={this.handleCancel}
@@ -134,6 +135,7 @@ class MessageDetailView extends React.Component<Props, State> {
         return (
           <AttestClaim
             claimerAddresses={[message.senderAddress]}
+            claimer={message.sender?.publicIdentity}
             requestForAttestation={
               (message.body as sdk.IRequestAttestationForClaim).content
                 .requestForAttestation

--- a/src/containers/Tasks/AttestClaim/AttestClaim.tsx
+++ b/src/containers/Tasks/AttestClaim/AttestClaim.tsx
@@ -11,6 +11,7 @@ import { BlockUi } from '../../../types/UserFeedback'
 type Props = {
   claimerAddresses: Array<IContact['publicIdentity']['address']>
   requestForAttestation: sdk.IRequestForAttestation
+  claimer?: sdk.IPublicIdentity
 
   onCancel?: () => void
   onFinished?: () => void
@@ -35,7 +36,12 @@ class AttestClaim extends React.Component<Props, State> {
   }
 
   private attestClaim(): void {
-    const { requestForAttestation, onFinished, claimerAddresses } = this.props
+    const {
+      requestForAttestation,
+      onFinished,
+      claimerAddresses,
+      claimer,
+    } = this.props
     const blockUi: BlockUi = FeedbackService.addBlockUi({
       headline: 'Writing attestation to chain',
     })
@@ -43,7 +49,8 @@ class AttestClaim extends React.Component<Props, State> {
     attestationWorkflow
       .approveAndSubmitAttestationForClaim(
         requestForAttestation,
-        claimerAddresses[0]
+        claimerAddresses[0],
+        claimer
       )
       .then(() => {
         blockUi.remove()

--- a/src/containers/Tasks/SubmitLegitimations/SubmitLegitimations.tsx
+++ b/src/containers/Tasks/SubmitLegitimations/SubmitLegitimations.tsx
@@ -20,6 +20,7 @@ import './SubmitLegitimations.scss'
 export type SubmitLegitimationsProps = {
   claim: sdk.IPartialClaim
   receiverAddresses: Array<IContact['publicIdentity']['address']>
+  receiver?: sdk.IPublicIdentity
 
   enablePreFilledClaim?: boolean
 
@@ -121,6 +122,7 @@ class SubmitLegitimations extends React.Component<Props, State> {
     const {
       getAttestedClaims,
       enablePreFilledClaim,
+      receiver,
       receiverAddresses,
       onFinished,
     } = this.props
@@ -134,6 +136,7 @@ class SubmitLegitimations extends React.Component<Props, State> {
       claim,
       getAttestedClaims(),
       receiverAddresses,
+      receiver,
       selectedDelegation
     ).then(() => {
       if (onFinished) {


### PR DESCRIPTION
## relates to KILTProtocol/ticket#467
This PR allows using public identities on messages instead of contacts for "submit terms" and "submit attestation".

## How to test:
- Use the anticov app

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
