### PR TITLE
Anticov delegation setup button

### DIFF
--- a/src/components/DevTools/DevTools.anticov.ts
+++ b/src/components/DevTools/DevTools.anticov.ts
@@ -58,7 +58,8 @@ async function verifyOrAddCtypeAndRoot(): Promise<void> {
     })
     notifySuccess(`CTYPE ${metadata.title.default} successfully created.`)
   }
-  // .verify() is fucked currently (at least with the mashnet)
+  // delegationRoot.verify() is unreliable when using the currently released mashnet-node & sdk
+  // workaround is checking the ctype hash of the query result; it is 0x000... if it doesn't exist on chain
   const queriedRoot = await sdk.DelegationRootNode.query(delegationRoot.id)
   if (queriedRoot?.cTypeHash !== ctype.hash) {
     await delegationRoot.store(root)

--- a/src/components/DevTools/DevTools.anticov.ts
+++ b/src/components/DevTools/DevTools.anticov.ts
@@ -1,6 +1,11 @@
 import * as sdk from '@kiltprotocol/sdk-js'
 import { IMetadata } from '@kiltprotocol/sdk-js/build/types/CTypeMetadata'
-import ANTICOV_CONFIG from './data/anticov.json'
+import {
+  ROOT_SEED,
+  CTYPE,
+  CTYPE_METADATA,
+  DELEGATION_ROOT_ID,
+} from './data/anticov.json'
 import { IMyIdentity } from '../../types/Contact'
 import CTypeRepository from '../../services/CtypeRepository'
 import { BalanceUtilities } from '../../services/BalanceUtilities'
@@ -11,28 +16,28 @@ import FeedbackService, {
   notifyFailure,
 } from '../../services/FeedbackService'
 
-const root = sdk.Identity.buildFromMnemonic(ANTICOV_CONFIG.ROOT_SEED)
+const root = sdk.Identity.buildFromMnemonic(ROOT_SEED)
 
-const ctype = sdk.CType.fromCType(ANTICOV_CONFIG.CTYPE as sdk.ICType)
+const ctype = sdk.CType.fromCType(CTYPE as sdk.ICType)
 ctype.owner = root.address
-const metadata: IMetadata = ANTICOV_CONFIG.CTYPE_METADATA
+const metadata: IMetadata = CTYPE_METADATA
 
 const delegationRoot = new sdk.DelegationRootNode(
-  ANTICOV_CONFIG.DELEGATION_ROOT_ID,
+  DELEGATION_ROOT_ID,
   ctype.hash,
   root.address
 )
 
-async function newDelegation(delegee: IMyIdentity): Promise<void> {
+async function newDelegation(delegate: IMyIdentity): Promise<void> {
   const delegationNode = new sdk.DelegationNode(
     sdk.UUID.generate(),
     delegationRoot.id,
-    delegee.identity.address,
+    delegate.identity.address,
     [sdk.Permission.ATTEST]
   )
-  const signature = delegee.identity.signStr(delegationNode.generateHash())
+  const signature = delegate.identity.signStr(delegationNode.generateHash())
   await delegationNode.store(root, signature)
-  notifySuccess(`Delegation successfully created for ${delegee.metaData.name}`)
+  notifySuccess(`Delegation successfully created for ${delegate.metaData.name}`)
   await DelegationsService.importDelegation(
     delegationNode.id,
     'AntiCov Attester',
@@ -44,7 +49,7 @@ async function newDelegation(delegee: IMyIdentity): Promise<void> {
     content: { delegationId: delegationNode.id, isPCR: false },
   }
   await MessageRepository.sendToAddresses(
-    [delegee.identity.address],
+    [delegate.identity.address],
     messageBody
   )
 }
@@ -75,19 +80,19 @@ async function verifyOrAddCtypeAndRoot(): Promise<void> {
   }
 }
 
-export async function setupAndDelegate(delegee: IMyIdentity): Promise<void> {
+export async function setupAndDelegate(delegate: IMyIdentity): Promise<void> {
   const blockUi = FeedbackService.addBlockUi({
     headline: 'Creating AntiCov Delegation',
   })
   try {
-    blockUi.updateMessage('transferring funds to AntiCov authority')
+    blockUi.updateMessage('Transferring funds to AntiCov authority')
     await new Promise(resolve => {
-      BalanceUtilities.makeTransfer(delegee, root.address, 4, () => resolve())
+      BalanceUtilities.makeTransfer(delegate, root.address, 4, () => resolve())
     })
-    blockUi.updateMessage('setting up CType and Root Delegation')
+    blockUi.updateMessage('Setting up CType and Root Delegation')
     await verifyOrAddCtypeAndRoot()
-    blockUi.updateMessage('creating Delegation Node for current identity')
-    await newDelegation(delegee)
+    blockUi.updateMessage('Creating Delegation Node for current identity')
+    await newDelegation(delegate)
   } catch (error) {
     notifyFailure(`Failed to set up Delegation Node: ${error}`)
   }

--- a/src/components/DevTools/DevTools.tsx
+++ b/src/components/DevTools/DevTools.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import setupAndDelegate from '../../utils/setupAnticov'
+import setupAndDelegate from './DevTools.anticov'
 import {
   ENDOWMENT,
   MIN_BALANCE,

--- a/src/components/DevTools/DevTools.tsx
+++ b/src/components/DevTools/DevTools.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import setupAndDelegate from '../../utils/setupAnticov'
 import {
   ENDOWMENT,
   MIN_BALANCE,
@@ -159,6 +160,15 @@ class DevTools extends React.Component<Props> {
                   {messages.label}
                 </button>
               ))}
+            </div>
+            <div>
+              <h4>AntiCov Setup</h4>
+              <button
+                type="button"
+                onClick={() => setupAndDelegate(selectedIdentity)}
+              >
+                AntiCov Delegation
+              </button>
             </div>
             {withMessages.map((messages: WithMessages) => (
               <div key={messages.label}>

--- a/src/components/DevTools/data/anticov.json
+++ b/src/components/DevTools/data/anticov.json
@@ -1,0 +1,18 @@
+{
+  "CTYPE": {
+    "schema": {
+      "$id": "anticov",
+      "$schema": "http://kilt-protocol.org/draft-01/ctype#",
+      "properties": {
+        "photo": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "hash": "0x005db4d03c57d15c47083cd363311669f0543e5647e26da1c5f12fe4fa8cd84d",
+    "owner": ""
+  },
+  "DELEGATION_ROOT_ID": "0x36656438633364382d393431372d346563392d386263612d3163646136346438",
+  "ROOT_SEED": "attract follow jealous bamboo document wine object edit cave mechanic clap flavor"
+}

--- a/src/components/DevTools/data/anticov.json
+++ b/src/components/DevTools/data/anticov.json
@@ -11,7 +11,23 @@
       "type": "object"
     },
     "hash": "0x005db4d03c57d15c47083cd363311669f0543e5647e26da1c5f12fe4fa8cd84d",
-    "owner": ""
+    "owner": "5Gtn4ZBVeqndGwt41AntNgSDCSBcsiyFr3NAm77UDGXbgxva"
+  },
+  "CTYPE_METADATA": {
+    "title": {
+      "default": "AntiCov"
+    },
+    "description": {
+      "default": "AntiCov Ctype"
+    },
+    "properties": {
+      "photo": {
+        "title": {
+          "default": "photo"
+        },
+        "description": {}
+      }
+    }
   },
   "DELEGATION_ROOT_ID": "0x36656438633364382d393431372d346563392d386263612d3163646136346438",
   "ROOT_SEED": "attract follow jealous bamboo document wine object edit cave mechanic clap flavor"

--- a/src/services/BalanceUtilities.tsx
+++ b/src/services/BalanceUtilities.tsx
@@ -129,11 +129,11 @@ class BalanceUtilities {
     )
   }
 
-  private static asKiltCoin(balance: BN): number {
+  public static asKiltCoin(balance: BN): number {
     return balance.divn(KILT_MICRO_COIN).toNumber()
   }
 
-  private static asMicroKilt(balance: number): BN {
+  public static asMicroKilt(balance: number): BN {
     return new BN(balance).muln(KILT_MICRO_COIN)
   }
 }

--- a/src/services/DelegationsService.ts
+++ b/src/services/DelegationsService.ts
@@ -91,16 +91,24 @@ class DelegationsService {
     if (delegation) {
       const root = await delegation.getRoot()
       const myDelegation: Delegations.IMyDelegation = {
-        account: delegation.account,
+        ...delegation,
         cTypeHash: root && root.cTypeHash,
-        id: delegation.id,
         isPCR,
         metaData: { alias },
-        parentId: delegation.parentId,
-        permissions: delegation.permissions,
         revoked: false,
-        rootId: delegation.rootId,
         type: Delegations.DelegationType.Node,
+      }
+      DelegationsService.store(myDelegation)
+      return myDelegation
+    }
+    const root = await DelegationsService.lookupRootNodeById(delegationNodeId)
+    if (root) {
+      const myDelegation: Delegations.IMyDelegation = {
+        ...root,
+        isPCR,
+        metaData: { alias },
+        revoked: false,
+        type: Delegations.DelegationType.Root,
       }
       DelegationsService.store(myDelegation)
       return myDelegation

--- a/src/services/MessageRepository.tsx
+++ b/src/services/MessageRepository.tsx
@@ -193,6 +193,17 @@ class MessageRepository {
       })
   }
 
+  public static async dispatchMessage(message: sdk.Message): Promise<Response> {
+    const response = await fetch(`${MessageRepository.URL}`, {
+      ...BasePostParams,
+      body: JSON.stringify(message.getEncryptedMessage()),
+    })
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    return response
+  }
+
   public static async singleSend(
     messageBody: sdk.MessageBody,
     sender: IMyIdentity,
@@ -207,17 +218,7 @@ class MessageRepository {
 
       message = await MessageRepository.handleDebugMode(message)
 
-      return fetch(`${MessageRepository.URL}`, {
-        ...BasePostParams,
-        body: JSON.stringify(message.getEncryptedMessage()),
-      })
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(response.statusText)
-          }
-          return response
-        })
-        .then(response => response.json())
+      return MessageRepository.dispatchMessage(message)
         .then(() => {
           notifySuccess(
             `Message '${messageBody.type}' to receiver ${receiver.metaData

--- a/src/utils/setupAnticov.ts
+++ b/src/utils/setupAnticov.ts
@@ -1,0 +1,80 @@
+import * as sdk from '@kiltprotocol/sdk-js'
+import { IMetadata } from '@kiltprotocol/sdk-js/build/types/CTypeMetadata'
+import { makeTransfer } from '@kiltprotocol/sdk-js/build/balance/Balance.chain'
+import { MessageBodyType } from '@kiltprotocol/sdk-js'
+import ANTICOV_CONFIG from '../components/DevTools/data/anticov.json'
+import CTypeRepository from '../services/CtypeRepository'
+import { BalanceUtilities } from '../services/BalanceUtilities'
+import { IMyIdentity } from '../types/Contact'
+import MessageRepository from '../services/MessageRepository'
+import { BasePostParams } from '../services/BaseRepository'
+
+const root = sdk.Identity.buildFromMnemonic(ANTICOV_CONFIG.ROOT_SEED)
+
+const ctype = sdk.CType.fromCType(ANTICOV_CONFIG.CTYPE as sdk.ICType)
+ctype.owner = root.address
+const metadata: IMetadata = {
+  title: { default: 'AntiCov' },
+  properties: { photo: { type: 'string' } },
+}
+
+const delegationRoot = new sdk.DelegationRootNode(
+  ANTICOV_CONFIG.DELEGATION_ROOT_ID,
+  ctype.hash,
+  root.address
+)
+
+async function newDelegation(myIdentity: IMyIdentity) {
+  const delNode = new sdk.DelegationNode(
+    sdk.UUID.generate(),
+    delegationRoot.id,
+    myIdentity.identity.address,
+    [sdk.Permission.ATTEST]
+  )
+  const signature = myIdentity.identity.signStr(delNode.generateHash())
+  await delNode.store(root, signature)
+  const messageBody: sdk.MessageBody = {
+    type: MessageBodyType.INFORM_CREATE_DELEGATION,
+    content: { delegationId: delNode.id, isPCR: false },
+  }
+  const message = new sdk.Message(
+    messageBody,
+    root,
+    myIdentity.identity.getPublicIdentity()
+  )
+  await fetch(`${MessageRepository.URL}`, {
+    ...BasePostParams,
+    body: JSON.stringify(message.getEncryptedMessage()),
+  }).then(response => {
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    console.log(response.json())
+  })
+}
+
+async function setup() {
+  if (!(await ctype.verifyStored())) {
+    await ctype.store(root)
+    CTypeRepository.register({
+      cType: ctype,
+      metaData: { metadata, ctypeHash: ctype.hash },
+    })
+  }
+
+  if (!(await delegationRoot.verify())) {
+    await delegationRoot.store(root)
+  }
+}
+
+export async function setupAndDelegate(myIdentity: IMyIdentity) {
+  await makeTransfer(
+    myIdentity.identity,
+    root.address,
+    BalanceUtilities.asMicroKilt(10)
+  )
+  await setup()
+  await newDelegation(myIdentity)
+}
+
+export default setupAndDelegate

--- a/src/utils/setupAnticov.ts
+++ b/src/utils/setupAnticov.ts
@@ -68,7 +68,9 @@ async function setup(): Promise<void> {
     }
     notifySuccess(`AntiCov Delegation Root successfully created.`)
     // sending root owner message for importing the root
-    await MessageRepository.sendToAddresses([root.address], messageBody)
+    const message = new sdk.Message(messageBody, root, root)
+    await MessageRepository.dispatchMessage(message)
+    notifySuccess(`Sent Delegation Root to AntiCov root authority.`)
   }
 }
 


### PR DESCRIPTION
## NO-TICKET
Because the devnet is reset on commits to develop (mashnet-node), Timo requested we set up a script to write the CType and delegation needed for AntiCov back to chain. We figured this would best be situated on the demo-client, where it now serves an additional purpose: Users can invite themselves to the AntiCov delegation tree with the click of a button.  

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
