### PR TITLE
push dev images to dockerhub

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -28,6 +28,7 @@ on:
   push:
     branches:
       - develop
+      - docker-dev
 
 name: Deploy to Amazon ECS
 
@@ -36,56 +37,56 @@ env:
   ECR_IMAGE_TAG: latest-develop
 
 jobs:
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
+  # deploy:
+  #   name: Deploy
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v1
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
+  #   - name: Configure AWS credentials
+  #     uses: aws-actions/configure-aws-credentials@v1
+  #     with:
+  #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #       aws-region: eu-central-1
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+  #   - name: Login to Amazon ECR
+  #     id: login-ecr
+  #     uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build, tag, and push image to Amazon ECR
-      id: build-image
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-      run: |
-        # Build a docker container and
-        # push it to ECR so that it can
-        # be deployed to ECS.
-        docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
-        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
+  #   - name: Build, tag, and push image to Amazon ECR
+  #     id: build-image
+  #     env:
+  #       ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+  #     run: |
+  #       # Build a docker container and
+  #       # push it to ECR so that it can
+  #       # be deployed to ECS.
+  #       docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG .
+  #       docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+  #       echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 
-    - name: Fill in the new image ID in the Amazon ECS task definition
-      id: task-def
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition.json
-        container-name: prototype-client
-        image: ${{ steps.build-image.outputs.image }}
+  #   - name: Fill in the new image ID in the Amazon ECS task definition
+  #     id: task-def
+  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #     with:
+  #       task-definition: task-definition.json
+  #       container-name: prototype-client
+  #       image: ${{ steps.build-image.outputs.image }}
 
-    - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: demo-client
-        cluster: kilt-devnet
-        wait-for-service-stability: true
+  #   - name: Deploy Amazon ECS task definition
+  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+  #     with:
+  #       task-definition: ${{ steps.task-def.outputs.task-definition }}
+  #       service: demo-client
+  #       cluster: kilt-devnet
+  #       wait-for-service-stability: true
 
   publish_to_docker:
     name: Publish develop image to docker
-    needs: deploy
+    # needs: deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -31,6 +31,10 @@ on:
 
 name: Deploy to Amazon ECS
 
+env:
+  ECR_REPOSITORY: kilt/demo-client
+  ECR_IMAGE_TAG: latest-develop
+
 jobs:
   deploy:
     name: Deploy
@@ -55,15 +59,13 @@ jobs:
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: kilt/demo-client
-        IMAGE_TAG: latest-develop
       run: |
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def
@@ -80,3 +82,37 @@ jobs:
         service: demo-client
         cluster: kilt-devnet
         wait-for-service-stability: true
+
+  publish_to_docker:
+    name: Publish develop image to docker
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      
+    - name: Login to Docker Hub
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      run: |
+        echo $DOCKER_PASS | docker login --username=$DOCKER_USER --password-stdin
+    - name: Tag and push dev image to Docker Hub
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        DOCKER_REPOSITORY: kiltprotocol/demo-client
+        DOCKER_IMAGE_TAG: develop
+      run: |
+        SOURCE_IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+        docker pull $SOURCE_IMAGE
+        docker tag $SOURCE_IMAGE $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG
+        docker push $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG


### PR DESCRIPTION
## part of KILTProtocol/ticket#530
This pushes dev images of the demo client to dockerhub with a dedicated tag (`develop`). These images are not super useful for local testing though; they are set up to connect to a kilt full node.

Outstanding issue(s):
- [ ] Images do not connect because connection config is wrong

## How to test:
A successful test run has been triggered by 89307a1 (see [here](https://github.com/KILTprotocol/demo-client/runs/761038453)). You can also pull the image from dockerhub (`kiltprotocol/demo-client`) and run it 

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
