### PR TITLE
ci: test with latest sdk

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -51,6 +51,13 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
+    - name: set up .npmrc & .yarnrc to connect to github packages
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10
+        registry-url: https://npm.pkg.github.com
+        scope: '@kiltprotocol'
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -61,7 +68,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,19 +2,18 @@ name: Lint and Test
 
 on:
   push:
-    branches: 
+    branches:
       - develop
       - master
     tags:
       - '*'
   pull_request:
-    branches: 
+    branches:
       - develop
       - master
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -22,15 +21,17 @@ jobs:
         node-version: [10.x, 12.x]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: yarn install, lint and build
-      run: |
-        yarn install --frozen-lockfile
-        yarn lint
-        # tests are not fully supported atm
-        # yarn testCI
-        yarn build
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://npm.pkg.github.com
+          scope: '@kiltprotocol'
+      - name: yarn install, lint and build
+        run: |
+          yarn upgrade --scope @kiltprotocol --latest
+          yarn lint
+          yarn build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM node:${NODE_VERSION}-alpine as develop
 WORKDIR /app
 
 COPY package.json yarn.lock ./
+COPY ?npmrc ?yarnrc ./
 RUN yarn install
 
 COPY . ./

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -1,14 +1,14 @@
-# superseded by building Dockerfile with --build-arg BUILD_ENV=.env.devnet
+# builds the demo client with the latest development version of the sdk published to the github package repository
 FROM node:10-alpine as builder
+ARG NODE_AUTH_TOKEN
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install
+COPY .npmrc .yarnrc ./
+RUN yarn upgrade --scope @kiltprotocol --latest
 
 COPY . ./
-RUN yarn lint
-#RUN yarn testCI
 RUN yarn build:devnet
 
 FROM nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - 27017:27017
   services:
-    image: kiltprotocol/demo-services
+    image: kiltprotocol/demo-services:develop
     environment:
       - NODE_ENV=docker-compose
       - MONGODB_HOST=mongodb
@@ -46,7 +46,7 @@ services:
       - mongodb
       - mashnet-node
   mashnet-node:
-    image: kiltprotocol/mashnet-node
+    image: kiltprotocol/mashnet-node:develop
     ports:
       - 9944:9944
     command: ./target/release/mashnet-node --dev --ws-port 9944 --ws-external


### PR DESCRIPTION
## fixes KILTProtocol/ticket#582
This uses a development version of the sdk and Portablegabi, published to [GitHub Packages](https://github.com/orgs/KILTprotocol/packages) to build devnet images and to run tests builds.

## How to test:
- [ ] fix typescript version issues with polkadot on sdk and merge to develop to trigger push to the GH packages repo
- [ ] re-run ci
- [ ] merge and hope the devnet image building actually works

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
