### PR TITLE
fix: devnet build with latest sdk

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: set up .npmrc to point to github packages
+      run: mv -f .npmrc.github .npmrc
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -50,13 +53,6 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
-
-    - name: set up .npmrc & .yarnrc to connect to github packages
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10
-        registry-url: https://npm.pkg.github.com
-        scope: '@kiltprotocol'
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -27,7 +27,7 @@
 on:
   push:
     branches:
-      - rf-test-with-latest-sdk
+      - develop
 
 name: Deploy to Amazon ECS
 
@@ -65,4 +65,21 @@ jobs:
         # push it to ECR so that it can
         # be deployed to ECS.
         docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: prototype-client
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: demo-client
+        cluster: kilt-devnet
+        wait-for-service-stability: true

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -27,7 +27,7 @@
 on:
   push:
     branches:
-      - develop
+      - rf-test-with-latest-sdk
 
 name: Deploy to Amazon ECS
 
@@ -65,21 +65,4 @@ jobs:
         # push it to ECR so that it can
         # be deployed to ECS.
         docker build -f Dockerfile.devnet -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-    - name: Fill in the new image ID in the Amazon ECS task definition
-      id: task-def
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition.json
-        container-name: prototype-client
-        image: ${{ steps.build-image.outputs.image }}
-
-    - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: demo-client
-        cluster: kilt-devnet
-        wait-for-service-stability: true

--- a/.npmrc.github
+++ b/.npmrc.github
@@ -1,0 +1,3 @@
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+@kiltprotocol:registry=https://npm.pkg.github.com
+always-auth=true

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -5,7 +5,7 @@ ARG NODE_AUTH_TOKEN
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-COPY .npmrc .yarnrc ./
+COPY .npmrc ./
 RUN yarn upgrade --scope @kiltprotocol --latest
 
 COPY . ./


### PR DESCRIPTION
## fixes #271 
The above mentioned PR had issues with building devnet images. I was under the assumption that the setup node action creates a `.npmrc` & `.yarnrc` file in the working directory, but I was mistaken. To fix this, I added a `.npmrc` template to the repository, with which I overwrite the `.npmrc` in the workflow.

## How to test
This time, I will demonstrate that it works by committing a [stub of the workflow that builds on this branch](https://github.com/KILTprotocol/demo-client/actions/runs/156534620), then revert. The container should successfully complete the `yarn upgrade` step and bump the sdk to a develop version, which we can tell from a commit hash included in the version number.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
