### PR TITLE
fix: delegation root node bug when switching identities

### DIFF
--- a/src/containers/DelegationCreate/DelegationCreate.tsx
+++ b/src/containers/DelegationCreate/DelegationCreate.tsx
@@ -45,13 +45,24 @@ class DelegationCreate extends React.Component<Props, State> {
     }
     this.handleNameChange = this.handleNameChange.bind(this)
     this.submit = this.submit.bind(this)
+    this.setDelegation = this.setDelegation.bind(this)
   }
 
   public componentDidMount(): void {
+    this.setDelegation()
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    const { selectedIdentity } = this.props
+    if (selectedIdentity !== prevProps.selectedIdentity) {
+      this.setDelegation()
+    }
+  }
+
+  public setDelegation(): void {
     const { match, selectedIdentity } = this.props
     const { cTypeHash } = match.params
     const { alias } = this.state
-
     if (selectedIdentity) {
       this.setState({
         alias,


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/620
When creating a Delegation root node switching accounts would not re-render the new account.

## How to test:

Create a new delegation and switch accounts.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
