### PR TITLE
feat: DID fetch on creating an identity

### DIFF
--- a/src/containers/WalletAdd/WalletAdd.tsx
+++ b/src/containers/WalletAdd/WalletAdd.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router'
 import { Link, withRouter } from 'react-router-dom'
+import DidService from '../../services/DidService'
 
 import Input from '../../components/Input/Input'
 import { BalanceUtilities } from '../../services/BalanceUtilities'
@@ -69,6 +70,7 @@ class WalletAdd extends React.Component<Props, State> {
     const { history, saveIdentity } = this.props
 
     let identity
+    let did
     const phrase = useMyPhrase ? myPhrase : randomPhrase
     try {
       identity = await Identity.buildFromMnemonic(phrase)
@@ -84,12 +86,22 @@ class WalletAdd extends React.Component<Props, State> {
     notify(`Creation of identity '${alias}' initiated.`)
     history.push('/wallet')
 
+    const didcheck = await DidService.fetchDID(identity)
+
+    if (didcheck) {
+      did = didcheck
+    }
+
     const newIdentity: IMyIdentity = {
       identity,
       metaData: {
         name: alias,
       },
       phrase,
+      did: {
+        identifier: did?.id,
+        document: did,
+      },
     }
     saveIdentity(newIdentity)
     PersistentStore.store.dispatch(

--- a/src/services/DidService.ts
+++ b/src/services/DidService.ts
@@ -1,6 +1,7 @@
 import {
   BlockchainUtils,
   Did,
+  Identity,
   IDid,
   IPublicIdentity,
   IURLResolver,
@@ -17,6 +18,23 @@ const { IS_IN_BLOCK } = BlockchainUtils
 
 class DidService {
   public static readonly URL = `${window._env_.REACT_APP_SERVICE_HOST}/contacts/did`
+
+  public static async fetchDID(
+    identity: Identity
+  ): Promise<IDidDocumentSigned | null> {
+    const did = await Did.queryByAddress(identity.address)
+    if (did) {
+      const didDocument = Did.createDefaultDidDocument(
+        did.identifier,
+        did.publicBoxKey,
+        did.publicSigningKey,
+        did.documentStore || undefined
+      )
+      return Did.signDidDocument(didDocument, identity)
+    }
+
+    return did
+  }
 
   public static async resolveDid(
     identifier: string

--- a/src/types/Contact.d.ts
+++ b/src/types/Contact.d.ts
@@ -1,5 +1,4 @@
-import { Identity, PublicIdentity } from '@kiltprotocol/sdk-js'
-import { IDidDocumentSigned } from '@kiltprotocol/sdk-js/build/did/Did'
+import { Identity, PublicIdentity, IDidDocument } from '@kiltprotocol/sdk-js'
 
 /**
  * as in prototype/services
@@ -13,7 +12,7 @@ export interface IContact {
   }
   did?: {
     identifier?: string
-    document?: IDidDocumentSigned
+    document?: IDidDocument
   }
 
   publicIdentity: PublicIdentity


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/1020

At the moment we don't check if an identity has a DID when adding the identity to the Demo-client

## How to test:

Add an identity with tokens to generate a DID.
Delete said identity and re-add with a mnemonic.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
