### PR TITLE
fix: tx submisson

### DIFF
--- a/src/components/DelegationNode/DelegationNode.tsx
+++ b/src/components/DelegationNode/DelegationNode.tsx
@@ -2,6 +2,7 @@ import {
   Attestation,
   DelegationNode as SDKDelegationNode,
   DelegationRootNode,
+  DelegationNodeUtils,
   SDKErrors,
   BlockchainUtils,
 } from '@kiltprotocol/sdk-js'
@@ -20,7 +21,6 @@ import FeedbackService, {
   notifyFailure,
   notifySuccess,
   notifyError,
-  notify,
 } from '../../services/FeedbackService'
 import * as Delegations from '../../state/ducks/Delegations'
 import { IMyDelegation } from '../../state/ducks/Delegations'
@@ -276,13 +276,6 @@ class DelegationNode extends React.Component<Props, State> {
 
     const hashes = await delegation.getAttestationHashes()
 
-    if (hashes.length < 1) {
-      notify(
-        <span>No attestations associated with this Delegation</span>,
-        false
-      )
-    }
-
     const delegationTitle = (
       <span>
         <strong>
@@ -300,8 +293,15 @@ class DelegationNode extends React.Component<Props, State> {
       }'`,
     })
 
-    const { steps } = await delegation.findAncestorOwnedBy(
-      selectedIdentity.identity.address
+    const firstAttestation = await Attestation.query(hashes[0])
+
+    if (firstAttestation === null) {
+      throw SDKErrors.ERROR_NOT_FOUND('Attestation not on chain')
+    }
+
+    const steps = await DelegationNodeUtils.countNodeDepth(
+      selectedIdentity.identity,
+      firstAttestation
     )
 
     await Promise.chain(
@@ -320,7 +320,7 @@ class DelegationNode extends React.Component<Props, State> {
         const tx = await Attestation.revoke(
           attestation.claimHash,
           selectedIdentity.identity,
-          steps + 1
+          steps
         )
 
         const result = await BlockchainUtils.submitTxWithReSign(

--- a/src/components/DelegationNode/DelegationNode.tsx
+++ b/src/components/DelegationNode/DelegationNode.tsx
@@ -21,6 +21,7 @@ import FeedbackService, {
   notifyFailure,
   notifySuccess,
   notifyError,
+  notify,
 } from '../../services/FeedbackService'
 import * as Delegations from '../../state/ducks/Delegations'
 import { IMyDelegation } from '../../state/ducks/Delegations'
@@ -276,6 +277,13 @@ class DelegationNode extends React.Component<Props, State> {
 
     const hashes = await delegation.getAttestationHashes()
 
+    if (hashes.length < 1) {
+      notify(
+        <span>No attestations associated with this Delegation</span>,
+        false
+      )
+    }
+
     const delegationTitle = (
       <span>
         <strong>
@@ -323,9 +331,13 @@ class DelegationNode extends React.Component<Props, State> {
           steps
         )
 
-        const result = await BlockchainUtils.submitSignedTx(tx, {
-          resolveOn: BlockchainUtils.IS_IN_BLOCK,
-        })
+        const result = await BlockchainUtils.submitTxWithReSign(
+          tx,
+          selectedIdentity.identity,
+          {
+            resolveOn: BlockchainUtils.IS_IN_BLOCK,
+          }
+        )
 
         return result
       }),

--- a/src/components/DelegationNode/DelegationNode.tsx
+++ b/src/components/DelegationNode/DelegationNode.tsx
@@ -2,7 +2,6 @@ import {
   Attestation,
   DelegationNode as SDKDelegationNode,
   DelegationRootNode,
-  DelegationNodeUtils,
   SDKErrors,
   BlockchainUtils,
 } from '@kiltprotocol/sdk-js'
@@ -301,15 +300,8 @@ class DelegationNode extends React.Component<Props, State> {
       }'`,
     })
 
-    const firstAttestation = await Attestation.query(hashes[0])
-
-    if (firstAttestation === null) {
-      throw SDKErrors.ERROR_NOT_FOUND('Attestation not on chain')
-    }
-
-    const steps = await DelegationNodeUtils.countNodeDepth(
-      selectedIdentity.identity,
-      firstAttestation
+    const { steps } = await delegation.findAncestorOwnedBy(
+      selectedIdentity.identity.address
     )
 
     await Promise.chain(
@@ -328,7 +320,7 @@ class DelegationNode extends React.Component<Props, State> {
         const tx = await Attestation.revoke(
           attestation.claimHash,
           selectedIdentity.identity,
-          steps
+          steps + 1
         )
 
         const result = await BlockchainUtils.submitTxWithReSign(

--- a/src/components/DevTools/DevTools.anticov.ts
+++ b/src/components/DevTools/DevTools.anticov.ts
@@ -73,7 +73,7 @@ async function newDelegation(delegate: IMyIdentity): Promise<void> {
   )
   const signature = delegate.identity.signStr(delegationNode.generateHash())
   const tx = await delegationNode.store(root, signature)
-  await BlockchainUtils.submitSignedTx(tx, { resolveOn: IS_IN_BLOCK })
+  await BlockchainUtils.submitTxWithReSign(tx, root, { resolveOn: IS_IN_BLOCK })
   notifySuccess(`Delegation successfully created for ${delegate.metaData.name}`)
   await DelegationsService.importDelegation(
     delegationNode.id,
@@ -95,7 +95,9 @@ async function verifyOrAddCtypeAndRoot(): Promise<void> {
   const { root, delegationRoot } = setup()
   if (!(await ctype.verifyStored())) {
     const tx = await ctype.store(root)
-    await BlockchainUtils.submitSignedTx(tx, { resolveOn: IS_IN_BLOCK })
+    await BlockchainUtils.submitTxWithReSign(tx, root, {
+      resolveOn: IS_IN_BLOCK,
+    })
     CTypeRepository.register({
       cType: ctype,
       metaData: { metadata, ctypeHash: ctype.hash },
@@ -106,7 +108,9 @@ async function verifyOrAddCtypeAndRoot(): Promise<void> {
   const queriedRoot = await DelegationRootNode.query(delegationRoot.id)
   if (queriedRoot?.cTypeHash !== ctype.hash) {
     const tx = await delegationRoot.store(root)
-    await BlockchainUtils.submitSignedTx(tx, { resolveOn: IS_IN_BLOCK })
+    await BlockchainUtils.submitTxWithReSign(tx, root, {
+      resolveOn: IS_IN_BLOCK,
+    })
     const messageBody: MessageBody = {
       type: MessageBodyType.INFORM_CREATE_DELEGATION,
       content: { delegationId: delegationRoot.id, isPCR: false },

--- a/src/components/DevTools/DevTools.ctypes.tsx
+++ b/src/components/DevTools/DevTools.ctypes.tsx
@@ -28,7 +28,7 @@ class BsCType {
       .identity
     const cType = CType.fromSchema(bsCTypeData.schema, ownerIdentity.address)
     const tx = cType.store(ownerIdentity)
-    await BlockchainUtils.submitSignedTx(await tx, {
+    await BlockchainUtils.submitTxWithReSign(await tx, ownerIdentity, {
       resolveOn: BlockchainUtils.IS_IN_BLOCK,
     })
     return tx

--- a/src/components/DevTools/DevTools.delegations.tsx
+++ b/src/components/DevTools/DevTools.delegations.tsx
@@ -1,8 +1,4 @@
-import {
-  DelegationNode,
-  DelegationRootNode,
-  BlockchainUtils,
-} from '@kiltprotocol/sdk-js'
+import { DelegationNode, DelegationRootNode } from '@kiltprotocol/sdk-js'
 import {
   IInformCreateDelegation,
   IRequestAcceptDelegation,
@@ -107,10 +103,7 @@ class BsDelegation {
 
     const signature = ownerIdentity.identity.signStr(delegation.generateHash())
     const metaData = { alias }
-    const tx = await DelegationsService.storeOnChain(delegation, signature)
-    await BlockchainUtils.submitSignedTx(tx, {
-      resolveOn: BlockchainUtils.IS_IN_BLOCK,
-    })
+    await DelegationsService.storeOnChain(delegation, signature)
     DelegationsService.store({
       cTypeHash: rootData.rootDelegation.cTypeHash,
       ...delegation,

--- a/src/containers/CtypeCreate/CtypeCreate.tsx
+++ b/src/containers/CtypeCreate/CtypeCreate.tsx
@@ -100,9 +100,13 @@ class CTypeCreate extends React.Component<Props, State> {
       }
 
       const tx = cType.store(selectedIdentity.identity)
-      await BlockchainUtils.submitSignedTx(await tx, {
-        resolveOn: BlockchainUtils.IS_IN_BLOCK,
-      })
+      await BlockchainUtils.submitTxWithReSign(
+        await tx,
+        selectedIdentity.identity,
+        {
+          resolveOn: BlockchainUtils.IS_IN_BLOCK,
+        }
+      )
       tx.then(() => {
         blockUi.updateMessage(
           `CTYPE stored on blockchain,\nnow registering CTYPE`

--- a/src/containers/Tasks/CreateDelegation/CreateDelegation.tsx
+++ b/src/containers/Tasks/CreateDelegation/CreateDelegation.tsx
@@ -4,7 +4,7 @@ import {
   ISubmitAcceptDelegation,
 } from '@kiltprotocol/types'
 import { Crypto } from '@kiltprotocol/utils'
-import { BlockchainUtils, DelegationNode } from '@kiltprotocol/sdk-js'
+import { DelegationNode } from '@kiltprotocol/sdk-js'
 
 import React from 'react'
 import { connect, MapStateToProps } from 'react-redux'
@@ -99,14 +99,7 @@ class CreateDelegation extends React.Component<Props, State> {
       optionalParentId
     )
 
-    const tx = await DelegationService.storeOnChain(
-      newDelegationNode,
-      signatures.invitee
-    )
-
-    BlockchainUtils.submitSignedTx(tx, {
-      resolveOn: BlockchainUtils.IS_IN_BLOCK,
-    })
+    await DelegationService.storeOnChain(newDelegationNode, signatures.invitee)
       .then(() => {
         notifySuccess(
           `${isPCR ? 'PCR member' : 'Delegation'} successfully created`

--- a/src/services/AttestationService.ts
+++ b/src/services/AttestationService.ts
@@ -54,7 +54,7 @@ class AttestationService {
 
     try {
       const tx = await attestation.store(selectedIdentity)
-      await BlockchainUtils.submitSignedTx(tx, {
+      await BlockchainUtils.submitTxWithReSign(tx, selectedIdentity, {
         resolveOn: IS_IN_BLOCK,
       })
     } catch (error) {
@@ -89,7 +89,9 @@ class AttestationService {
         delegationTreeTraversalSteps
       )
 
-      await BlockchainUtils.submitSignedTx(tx, { resolveOn: IS_IN_BLOCK })
+      await BlockchainUtils.submitTxWithReSign(tx, selectedIdentity, {
+        resolveOn: IS_IN_BLOCK,
+      })
       notifySuccess('Attestation successfully revoked')
       persistentStoreInstance.store.dispatch(
         Attestations.Store.revokeAttestation(attestation.claimHash)
@@ -125,7 +127,7 @@ class AttestationService {
         delegationTreeTraversalSteps
       )
 
-      await BlockchainUtils.submitSignedTx(tx, {
+      await BlockchainUtils.submitTxWithReSign(tx, selectedIdentity, {
         resolveOn: IS_IN_BLOCK,
       })
 

--- a/src/services/BalanceUtilities.tsx
+++ b/src/services/BalanceUtilities.tsx
@@ -77,7 +77,7 @@ class BalanceUtilities {
     )
     Balance.makeTransfer(myIdentity.identity, receiverAddress, transferAmount)
       .then(tx =>
-        BlockchainUtils.submitSignedTx(tx, {
+        BlockchainUtils.submitTxWithReSign(tx, myIdentity.identity, {
           resolveOn: BlockchainUtils.IS_IN_BLOCK,
         })
       )

--- a/src/services/DidService.ts
+++ b/src/services/DidService.ts
@@ -88,9 +88,13 @@ class DidService {
     } as IContact)
 
     const tx = await did.store(myIdentity.identity)
-    const status = await BlockchainUtils.submitSignedTx(tx, {
-      resolveOn: IS_IN_BLOCK,
-    })
+    const status = await BlockchainUtils.submitTxWithReSign(
+      tx,
+      myIdentity.identity,
+      {
+        resolveOn: IS_IN_BLOCK,
+      }
+    )
     if (status.isError) {
       throw new Error(
         `Error creating DID for identity ${myIdentity.metaData.name}`
@@ -107,9 +111,13 @@ class DidService {
 
   public static async deleteDid(myIdentity: IMyIdentity): Promise<void> {
     const tx = await Did.remove(myIdentity.identity)
-    const status = await BlockchainUtils.submitSignedTx(tx, {
-      resolveOn: IS_IN_BLOCK,
-    })
+    const status = await BlockchainUtils.submitTxWithReSign(
+      tx,
+      myIdentity.identity,
+      {
+        resolveOn: IS_IN_BLOCK,
+      }
+    )
     if (status.isError) {
       throw new Error(
         `Error deleting DID for identity ${myIdentity.metaData.name}`


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1167
Switching to `submitTxWithResign` fixes the issue of extrinsic errors going unnoticed (this uses defaults for `rejectOn`).

## How to test:
Try different transactions that must fail - attesting on a revoked delegationNode etc.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
