### PR TITLE
fix: claim property removal during claim submission affected stored claims

### DIFF
--- a/src/services/AttestationService.ts
+++ b/src/services/AttestationService.ts
@@ -197,7 +197,8 @@ class AttestationService {
         state.selectedAttestedClaims.forEach(
           (selectedAttestedClaim: IAttestedClaim) => {
             const attClaim = AttestedClaim.fromAttestedClaim(
-              selectedAttestedClaim
+              // deep copy to avoid deleting properties on the original object
+              JSON.parse(JSON.stringify(selectedAttestedClaim))
             )
 
             attClaim.request.removeClaimProperties(


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1218
As far as I can tell, the issue was related to improper copying of the AttestedClaim object before removing properties (which internally just calls `delete` on them). This led to removal on the original object in state as well as on the copy.

## How to test:
Proceed as in the ticket; this should no longer be the case.

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
