### PR TITLE
fix: revoking attestations on node w/o attestations blocked ui

### DIFF
--- a/src/components/DelegationNode/DelegationNode.tsx
+++ b/src/components/DelegationNode/DelegationNode.tsx
@@ -2,7 +2,6 @@ import {
   Attestation,
   DelegationNode as SDKDelegationNode,
   DelegationRootNode,
-  DelegationNodeUtils,
   SDKErrors,
   BlockchainUtils,
 } from '@kiltprotocol/sdk-js'
@@ -21,6 +20,7 @@ import FeedbackService, {
   notifyFailure,
   notifySuccess,
   notifyError,
+  notify,
 } from '../../services/FeedbackService'
 import * as Delegations from '../../state/ducks/Delegations'
 import { IMyDelegation } from '../../state/ducks/Delegations'
@@ -276,6 +276,14 @@ class DelegationNode extends React.Component<Props, State> {
 
     const hashes = await delegation.getAttestationHashes()
 
+    if (hashes.length < 1) {
+      notify(
+        <span>No attestations associated with this Delegation</span>,
+        false
+      )
+      return
+    }
+
     const delegationTitle = (
       <span>
         <strong>
@@ -293,15 +301,8 @@ class DelegationNode extends React.Component<Props, State> {
       }'`,
     })
 
-    const firstAttestation = await Attestation.query(hashes[0])
-
-    if (firstAttestation === null) {
-      throw SDKErrors.ERROR_NOT_FOUND('Attestation not on chain')
-    }
-
-    const steps = await DelegationNodeUtils.countNodeDepth(
-      selectedIdentity.identity,
-      firstAttestation
+    const { steps } = await delegation.findAncestorOwnedBy(
+      selectedIdentity.identity.address
     )
 
     await Promise.chain(
@@ -320,7 +321,7 @@ class DelegationNode extends React.Component<Props, State> {
         const tx = await Attestation.revoke(
           attestation.claimHash,
           selectedIdentity.identity,
-          steps
+          steps + 1
         )
 
         const result = await BlockchainUtils.submitSignedTx(tx, {


### PR DESCRIPTION
## NO TICKET
The demo-client allows users to click the "Revoke all attestations" button even for nodes to which no attestations are linked. 
But trying to revoke all attestations by a delegation node would block the client if the delegation node had no attestations.
This fix introduces an early exit when no attestations are found (with the UI remaining unblocked), and notifies the user. 

## How to test:
Simply create a new DelegationNode, then click the "Revoke All Attestations" button on it. This would formerly block the UI.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
