### PR TITLE
fix: display attestation status in claims list

### DIFF
--- a/src/state/ducks/Claims.ts
+++ b/src/state/ducks/Claims.ts
@@ -220,7 +220,13 @@ class Store {
               (attestedClaim: IAttestedClaim, index: number) => {
                 if (attestedClaim.attestation.claimHash === revokedHash) {
                   // avoid changing claims while iterating
-                  setIns.push([myClaimHash, 'attestedClaims', index, 'revoked'])
+                  setIns.push([
+                    myClaimHash,
+                    'attestedClaims',
+                    index,
+                    'attestation',
+                    'revoked',
+                  ])
                 }
               }
             )


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1269
Fixes an issue where the revocation status was not correctly displayed in the claims list because the state was updated incorrectly.

This is the result of a state update before the fix: 
![image](https://user-images.githubusercontent.com/39338561/116380702-7e7f0d00-a814-11eb-9e92-1c1055d19519.png)

As you can see, the `revoked` property was set on the wrong object, one level too high.

## How to test:
Attest a claim, revoke it, then navigate to the claims list. While the revoked claim may still show a green check mark, it should switch to a red `x` after you entered the claim detail view once (clicking on the claim alias, then going back to the list view).

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
