### PR TITLE
chore: do not attempt deployment on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,20 +41,6 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-    - name: Configure Kubernetes
-      env:
-        KUBECONFIG: '${{ github.workspace }}/.kube/kubeconfig'
-      run: |
-        mkdir -p '${{ github.workspace }}/.kube' \
-          && echo '${{ secrets.KUBE_CONFIG}}' | base64 -d > $KUBECONFIG
-
-    - name: Set new image
-      env:
-        IMAGE: ${{ steps.build-image.outputs.image }}
-        KUBECONFIG: '${{ github.workspace }}/.kube/kubeconfig'
-      run: |
-        kubectl -n testnet set image deployment/client-deployment client-container=$IMAGE
-
   buildDocker:
     name: Build image and push to Docker Hub
     runs-on: ubuntu-latest


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1279
Removes steps to set new image on mashnet in the release workflow.
Deployment to devnet is still triggered on push to develop.  

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
